### PR TITLE
update docs to reflect latest jbang 0.60.1

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,11 +4,14 @@ Simple `limit` plugin to set limits on your container.
 
 To install use [jbang](https://jbang.dev/download):
 
-   jbang app install --name kubectl-limit kubectl-limit@sebastienblanc/limit-request
+    jbang app install kubectl-limit@sebastienblanc/limit-request
 
 or via curl:
 
-   curl -Ls https://sh.jbang.dev | bash - app install kubectl-limit@sebastienblanc/limit-request
+    curl -Ls https://sh.jbang.dev | bash - app install kubectl-limit@sebastienblanc/limit-request
 
-Now `kubectl limit` ....
+If you have GraalVM available set GRAALVM_HOME environment variable and you can use 
+`jbang app install --native kubectl-limit@sebastienblanc/limit-request`
+
+Now `kubectl limit` ...
 


### PR DESCRIPTION
0.60.0 fixed it so --name was not necessary
0.60.1 fixed it so `jbang install --native ..` works.